### PR TITLE
internal transfer

### DIFF
--- a/custodian/README.md
+++ b/custodian/README.md
@@ -19,7 +19,7 @@ This script requires the following Python libraries:
 
 You can install these dependencies using `pip`:
 ```
-pip install requests
+pip install requests "pyjwt[crypto]"
 ```
 
 ### Environment Variables
@@ -28,6 +28,9 @@ The script relies on the following environment variables:
 - **`API_KEY_SECRET`**: The API key secret corresponding to the API key ID.
 - **`API_KEY_SCOPE`**: The scope of the API key.
 - **`BASE_URL`** (optional): The base URL of the API. Defaults to `https://api.sandbox.paxos.com`.
+- **`OAUTH_URL`** (optional): The OAuth token endpoint base URL. Defaults to `https://oauth.sandbox.paxos.com`.
+- **`PAXOS_SIGNING_KEY_PATH`** (optional): Path to the PEM private key file for JWS request signing. Required for endpoints that enforce request signing (e.g., `/v2/transfer/internal`).
+- **`PAXOS_SIGNING_KEY_ID`** (optional): The Key ID (from Paxos Dashboard) corresponding to the signing key. Required alongside `PAXOS_SIGNING_KEY_PATH`.
 
 ## Usage
 

--- a/custodian/paxos.py
+++ b/custodian/paxos.py
@@ -3,11 +3,16 @@ import requests
 import sys
 import argparse
 import json
+import time
 from datetime import datetime, timedelta
 
+import jwt
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519
+
 # Function to acquire a token
-def get_token(api_key_id, api_key_secret, api_key_scope, base_url, args):
-    auth_url = f"{base_url}/oauth2/token"
+def get_token(api_key_id, api_key_secret, api_key_scope, oauth_url, args):
+    auth_url = f"{oauth_url}/oauth2/token"
     body = {
         "grant_type": "client_credentials",
         "client_id": api_key_id,
@@ -24,34 +29,66 @@ def get_token(api_key_id, api_key_secret, api_key_scope, base_url, args):
             raise ValueError("Missing token or expiration in response")
         
         expiration_time = datetime.utcnow() + timedelta(seconds=expires_in)
-        if args.raw != True:
+        if not getattr(args, 'raw', False):
             print(f"Acquired token successfully. Expires in {expires_in} seconds (at {expiration_time}).")
         return access_token
     else:
         raise RuntimeError(f"Failed to acquire token. HTTP {response.status_code}: {response.text}")
 
+# Generate a JWS signature for Paxos request signing
+def _detect_algorithm(signing_key):
+    key = load_pem_private_key(signing_key, password=None)
+    if isinstance(key, ec.EllipticCurvePrivateKey):
+        return "ES256"
+    elif isinstance(key, ed25519.Ed25519PrivateKey):
+        return "EdDSA"
+    else:
+        raise ValueError(f"Unsupported key type: {type(key)}")
+
+def sign_request(method, path, body_bytes, signing_key, signing_key_id):
+    alg = _detect_algorithm(signing_key)
+    jws_headers = {
+        "kid": signing_key_id,
+        "alg": alg,
+        "paxos.com/timestamp": str(int(time.time())),
+        "paxos.com/request-method": method.upper(),
+        "paxos.com/request-path": path,
+    }
+    return jwt.api_jws.encode(
+        payload=body_bytes,
+        key=signing_key,
+        headers=jws_headers,
+        algorithm=alg,
+    )
+
 # Function to make an API request
-def make_request(base_url, token, method, path, body=None):
+def make_request(base_url, token, method, path, body=None, signing_key=None, signing_key_id=None):
     url = f"{base_url}{path}"
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json"
     }
     method = method.lower()
-    
+
+    # Use raw body bytes so the JWS payload matches exactly what's sent
+    body_bytes = body.encode("utf-8") if body else b""
+
+    if signing_key and signing_key_id:
+        headers["Paxos-Signature"] = sign_request(method, path, body_bytes, signing_key, signing_key_id)
+
     if method == "get":
         response = requests.get(url, headers=headers)
     elif method == "post":
-        response = requests.post(url, headers=headers, json=json.loads(body) if body else None)
+        response = requests.post(url, headers=headers, data=body_bytes)
     elif method == "put":
-        response = requests.put(url, headers=headers, json=json.loads(body) if body else None)
+        response = requests.put(url, headers=headers, data=body_bytes)
     elif method == "delete":
         response = requests.delete(url, headers=headers)
     elif method == "patch":
-        response = requests.patch(url, headers=headers, json=json.loads(body) if body else None)
+        response = requests.patch(url, headers=headers, data=body_bytes)
     else:
         raise ValueError(f"Unsupported method: {method}")
-    
+
     return response
 
 # Main function to parse arguments and execute the script
@@ -70,20 +107,28 @@ def main():
     api_key_secret = os.getenv("API_KEY_SECRET")
     api_key_scope = os.getenv("API_KEY_SCOPE")
     base_url = os.getenv("BASE_URL", "https://api.sandbox.paxos.com")
-    
+    oauth_url = os.getenv("OAUTH_URL", "https://oauth.sandbox.paxos.com")
+    signing_key_path = os.getenv("PAXOS_SIGNING_KEY_PATH")
+    signing_key_id = os.getenv("PAXOS_SIGNING_KEY_ID")
+
     if not api_key_id or not api_key_secret or not api_key_scope:
         print("Error: API_KEY_ID, API_KEY_SECRET, and API_KEY_SCOPE must be set as environment variables.")
         sys.exit(1)
 
+    signing_key = None
+    if signing_key_path and signing_key_id:
+        with open(signing_key_path, "rb") as f:
+            signing_key = f.read()
+
     try:
         # Get token
-        token = get_token(api_key_id, api_key_secret, api_key_scope, base_url, args)
-        
+        token = get_token(api_key_id, api_key_secret, api_key_scope, oauth_url, args)
+
         # Make the request
-        response = make_request(base_url, token, args.method, args.path, args.body)
+        response = make_request(base_url, token, args.method, args.path, args.body, signing_key, signing_key_id)
         
         # Output the response
-        if args.raw != True:
+        if not getattr(args, 'raw', False):
             print(f"Status Code: {response.status_code}")
         if args.pretty == True:
             print(json.dumps(response.json(), indent=4))

--- a/exchange/rest/internal_transfer.py
+++ b/exchange/rest/internal_transfer.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import argparse
+import json
+import uuid
+
+# Add project root to path so we can import sibling packages
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from custodian.paxos import get_token as paxos_get_token, make_request as paxos_make_request
+from exchange.rest.rest import make_request as exchange_make_request
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Perform an internal transfer between Paxos profiles and notify the exchange.")
+    parser.add_argument("--from-profile", required=True, help="Source Paxos profile ID")
+    parser.add_argument("--to-profile", required=True, help="Destination Paxos profile ID")
+    parser.add_argument("--asset", required=True, help="Asset to transfer (e.g., USD, PYUSD)")
+    parser.add_argument("--amount", required=True, help="Amount to transfer")
+    parser.add_argument("--client-id", required=True, help="Exchange client ID")
+    parser.add_argument("--asset-id", required=True, help="Exchange asset ID for the transfer notification")
+    parser.add_argument("--server", type=str, default="uat.truex.co:9742", help="Exchange REST API host:port")
+
+    args = parser.parse_args()
+
+    # Load Paxos credentials from environment
+    api_key_id = os.getenv("API_KEY_ID")
+    api_key_secret = os.getenv("API_KEY_SECRET")
+    api_key_scope = os.getenv("API_KEY_SCOPE")
+    base_url = os.getenv("BASE_URL", "https://api.sandbox.paxos.com")
+    oauth_url = os.getenv("OAUTH_URL", "https://oauth.sandbox.paxos.com")
+    signing_key_path = os.getenv("PAXOS_SIGNING_KEY_PATH")
+    signing_key_id = os.getenv("PAXOS_SIGNING_KEY_ID")
+
+    if not api_key_id or not api_key_secret or not api_key_scope:
+        print("Error: API_KEY_ID, API_KEY_SECRET, and API_KEY_SCOPE must be set as environment variables.")
+        sys.exit(1)
+
+    if not signing_key_path or not signing_key_id:
+        print("Error: PAXOS_SIGNING_KEY_PATH and PAXOS_SIGNING_KEY_ID must be set for internal transfers.")
+        sys.exit(1)
+
+    with open(signing_key_path, "rb") as f:
+        signing_key = f.read()
+
+    # Step 1: Initiate internal transfer on Paxos
+    print("Acquiring Paxos OAuth token...")
+    token = paxos_get_token(api_key_id, api_key_secret, api_key_scope, oauth_url, args)
+
+    transfer_body = json.dumps({
+        "ref_id": str(uuid.uuid4()),
+        "from_profile_id": args.from_profile,
+        "to_profile_id": args.to_profile,
+        "amount": args.amount,
+        "asset": args.asset,
+    })
+
+    print(f"Initiating Paxos internal transfer: {args.amount} {args.asset} from {args.from_profile} to {args.to_profile}...")
+    paxos_response = paxos_make_request(base_url, token, "post", "/v2/transfer/internal", transfer_body, signing_key, signing_key_id)
+
+    if paxos_response.status_code != 200:
+        print(f"Paxos transfer failed. HTTP {paxos_response.status_code}: {paxos_response.text}")
+        sys.exit(1)
+
+    paxos_data = paxos_response.json()
+    transfer_id = paxos_data.get("id")
+    if not transfer_id:
+        print(f"Error: No transfer ID in Paxos response: {json.dumps(paxos_data, indent=2)}")
+        sys.exit(1)
+
+    print(f"Paxos transfer initiated successfully. Transfer ID: {transfer_id}")
+
+    # Step 2: Notify the exchange
+    exchange_body = json.dumps({
+        "request": {
+            "asset_id": args.asset_id,
+            "client_id": args.client_id,
+            "platform": "INTERNAL",
+            "type": "DEPOSIT",
+            "amount": args.amount,
+            "instructions": {
+                "transfer_id": transfer_id
+            }
+        }
+    })
+
+    print(f"Notifying exchange of transfer...")
+    exchange_response = exchange_make_request(args.server, "transfer", "post", exchange_body, args.client_id)
+
+    if exchange_response.status_code == 200:
+        print("Exchange notified successfully:")
+        print(json.dumps(exchange_response.json(), indent=4))
+    else:
+        print(f"Exchange notification failed. HTTP {exchange_response.status_code}: {exchange_response.text}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/exchange/rest/rest.py
+++ b/exchange/rest/rest.py
@@ -8,69 +8,73 @@ import os
 import argparse
 from urllib.parse import urlparse
 
-parser = argparse.ArgumentParser(description="Get the Client IDs affiliated with the API key")
-
-# Add the --name argument with a default value of "World"
-parser.add_argument('--server', type=str, default="uat1.truex.co:9742", help='The host and port of the REST API')
-parser.add_argument('--path', type=str, default="", help='URL path of the API call')
-parser.add_argument('--method', type=str, default="", help='Type of http request: get, post, patch, delete')
-parser.add_argument('--body', type=str, default="", help='JSON payload for post and patch')
-parser.add_argument('--client', type=str, default="0", help='Client ID to use in header')
-
-# Parse the command-line arguments
-args = parser.parse_args()
-
 # Define the constants for the headers
 HEADER_AUTH_TIMESTAMP = "x-truex-auth-timestamp"
 HEADER_AUTH_SIGNATURE = "x-truex-auth-signature"
 HEADER_AUTH_TOKEN = "x-truex-auth-token"
 HEADER_AUTH_USER_ID = "x-truex-auth-user-id"
 
-# Assuming the secret and token are fetched from a secure source
-auth_token = os.getenv("TRUEX_KEY_ID")
-secret_key = os.getenv("TRUEX_KEY_SECRET")
 
-# Example of the URL
-url = "http://" + str(args.server) + "/api/v1/" + str(args.path)  # Replace with your REST endpoint
+def sign_request(secret_key, method, path, body, timestamp):
+    """Create an HMAC signature for the given request parameters."""
+    payload = timestamp + method.upper() + path + body
+    hmac_key = secret_key.encode('utf-8')
+    hmac_message = payload.encode('utf-8')
+    hmac_digest = hmac.new(hmac_key, hmac_message, hashlib.sha256).digest()
+    return base64.b64encode(hmac_digest).decode('utf-8')
 
-# Prepare the current timestamp and method
-auth_timestamp = str(int(time.time()))  # Unix timestamp as string
-method = str(args.method).lower()
 
-# Combine the values into a payload for HMAC
-parsed_url = urlparse(url)
-path = parsed_url.path
-payload = auth_timestamp + method.upper() + path + str(args.body)
+def make_request(server, path, method, body="", client_id="0", auth_token=None, secret_key=None):
+    """Make an authenticated request to the exchange REST API."""
+    if auth_token is None:
+        auth_token = os.getenv("TRUEX_KEY_ID")
+    if secret_key is None:
+        secret_key = os.getenv("TRUEX_KEY_SECRET")
 
-# Create HMAC signature using the secret key
-hmac_key = secret_key.encode('utf-8')
-hmac_message = payload.encode('utf-8')
-hmac_digest = hmac.new(hmac_key, hmac_message, hashlib.sha256).digest()
+    url = "http://" + server + "/api/v1/" + path
+    parsed_url = urlparse(url)
+    url_path = parsed_url.path
 
-# Convert the HMAC result to base64
-auth_signature = base64.b64encode(hmac_digest).decode('utf-8')
+    auth_timestamp = str(int(time.time()))
+    method = method.lower()
 
-# Setup the headers for the request
-headers = {
-    HEADER_AUTH_TIMESTAMP: auth_timestamp,
-    HEADER_AUTH_SIGNATURE: auth_signature,
-    HEADER_AUTH_TOKEN: auth_token,
-    HEADER_AUTH_USER_ID: str(args.client),
-    "Content-Type": "application/json"
-}
+    auth_signature = sign_request(secret_key, method, url_path, body, auth_timestamp)
 
-response = None
-if method == "get":
-    response = requests.get(url, headers=headers)
-elif method == "post":
-    response = requests.post(url, headers=headers, data=str(args.body))
-elif method == "patch":
-    response = requests.patch(url, headers=headers, data=str(args.body))
-elif method == "delete":
-    response = requests.delete(url, headers=headers)
+    headers = {
+        HEADER_AUTH_TIMESTAMP: auth_timestamp,
+        HEADER_AUTH_SIGNATURE: auth_signature,
+        HEADER_AUTH_TOKEN: auth_token,
+        HEADER_AUTH_USER_ID: str(client_id),
+        "Content-Type": "application/json"
+    }
 
-# Check the response
-if response.status_code == 200:
-    print("Success:", json.dumps(response.json(), indent=4))  # Assuming the response is JSON
-else:
-    print(f"Failed with status code {response.status_code}: {response.text}")
+    response = None
+    if method == "get":
+        response = requests.get(url, headers=headers)
+    elif method == "post":
+        response = requests.post(url, headers=headers, data=body)
+    elif method == "patch":
+        response = requests.patch(url, headers=headers, data=body)
+    elif method == "delete":
+        response = requests.delete(url, headers=headers)
+
+    return response
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Get the Client IDs affiliated with the API key")
+
+    parser.add_argument('--server', type=str, default="uat1.truex.co:9742", help='The host and port of the REST API')
+    parser.add_argument('--path', type=str, default="", help='URL path of the API call')
+    parser.add_argument('--method', type=str, default="", help='Type of http request: get, post, patch, delete')
+    parser.add_argument('--body', type=str, default="", help='JSON payload for post and patch')
+    parser.add_argument('--client', type=str, default="0", help='Client ID to use in header')
+
+    args = parser.parse_args()
+
+    response = make_request(args.server, args.path, args.method, args.body, args.client)
+
+    if response.status_code == 200:
+        print("Success:", json.dumps(response.json(), indent=4))
+    else:
+        print(f"Failed with status code {response.status_code}: {response.text}")


### PR DESCRIPTION
used to test paxos deposit notification flow

creates an internal transfer within paxos and then call the trading transfer endpoint notifying of an internal deposit

success in dsv pointing against paxos sandbox
```
$ python exchange/rest/internal_transfer.py --from-profile <from-profile> --to-profile <to-profile> --asset PYUSD --amount <amount> --client-id <client-id> --asset-id <asset-id> --server <server>

Exchange notified successfully:
{
    "id": "<id>",
    "status": "PROCESSING",
    "request": {
        "amount": "10",
        "asset_id": "<asset_id>",
        "client_id": "<client_id>",
        "type": "DEPOSIT",
        "platform": "INTERNAL",
        "instructions": {
            "transfer_id": "<paxos_transfer_id>"
        }
    }
}
```
